### PR TITLE
Revert colors to normal if ssh login interrupted

### DIFF
--- a/safe_ssh
+++ b/safe_ssh
@@ -28,6 +28,10 @@ profile='Profile4'
 # Select profile3 for production
 [[ "$last" =~ "production" ]] && profile='Profile3'
 
+#Makes sure that if ssh login is interrupted with Ctrl+C, the colors
+#go back to normal
+trap '"$__PROF_CHANGE" --change "$__TERM_PROF" "Default"' SIGINT
+
 "$__PROF_CHANGE" --change "$__TERM_PROF" "$profile"
 
 /usr/bin/ssh $@

--- a/term
+++ b/term
@@ -37,5 +37,5 @@ if [ -n "$1" ]; then
 else
 	prof="`mktemp -u HACK_PROFILE_XXXXXXXXXX`"
 	create_profile "$prof" "$default"
-	gnome-terminal --window-with-profile="$prof" -x sh -c "export __TERM_PROF='$prof' && export __PROF_CHANGE='$this' && '$SHELL' && '$this' --delete '$prof'"
+	gnome-terminal --working-directory=$HOME --window-with-profile="$prof" -x sh -c "export __TERM_PROF='$prof' && export __PROF_CHANGE='$this' && '$SHELL' && '$this' --delete '$prof'"
 fi


### PR DESCRIPTION
In the original code, if you try to ssh into a system, and hit Ctrl+C to back out instead of entering the password, the Profile does not go back to the original. My first commit fixes that.

The second commit is also a small change that always has gnome-terminal starting in the user's home directory, instead of wherever the 'term' script is run from.

Sidenote: I've been looking for a way to make gnome-terminal change color when SSHing into other systems for months. I can't believe how simple your scripts are to use, and that I didn't find them earlier. Thanks!

Why has the gnome-terminal team not built this functionality into the application? Seems like it would be a relatively easy thing to do.
